### PR TITLE
general-user-refatoring

### DIFF
--- a/prisma/migrations/20230613095422_test/migration.sql
+++ b/prisma/migrations/20230613095422_test/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "description" DROP NOT NULL,
+ALTER COLUMN "is_seller" DROP NOT NULL;

--- a/prisma/migrations/20230613131041_migrate_test_mod/migration.sql
+++ b/prisma/migrations/20230613131041_migrate_test_mod/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Made the column `is_seller` on table `users` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "is_seller" SET NOT NULL,
+ALTER COLUMN "is_seller" DROP DEFAULT;

--- a/prisma/migrations/20230613135652_new_migration/migration.sql
+++ b/prisma/migrations/20230613135652_new_migration/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `description` on table `users` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "description" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,8 +18,8 @@ model User {
   cpf         String    @unique @db.VarChar(11)
   phone       String    @db.VarChar(11)
   birthdate   String    @db.VarChar(8)
-  description String?    @db.Text()
-  is_seller   Boolean?   @default(false) @db.Boolean()
+  description String   @db.Text()
+  is_seller   Boolean   @db.Boolean()
   address     Adresses?
   ads         Ads[]
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,8 +18,8 @@ model User {
   cpf         String    @unique @db.VarChar(11)
   phone       String    @db.VarChar(11)
   birthdate   String    @db.VarChar(8)
-  description String    @db.Text()
-  is_seller   Boolean   @default(false) @db.Boolean()
+  description String?    @db.Text()
+  is_seller   Boolean?   @default(false) @db.Boolean()
   address     Adresses?
   ads         Ads[]
 

--- a/src/controllers/user/create.controller.ts
+++ b/src/controllers/user/create.controller.ts
@@ -4,7 +4,7 @@ import { TUserRequest, TUserResponse } from "../../interfaces/user.interfaces"
 
 
 
-const createUserController = async (req: Request, res: Response) => {
+export const createUserController = async (req: Request, res: Response): Promise<Response> => {
 
     const data: TUserRequest = req.body
 
@@ -14,5 +14,3 @@ const createUserController = async (req: Request, res: Response) => {
 
 }
 
-
-export { createUserController }

--- a/src/controllers/user/delete.controller.ts
+++ b/src/controllers/user/delete.controller.ts
@@ -3,7 +3,7 @@ import { deleteUserService } from "../../services/user/delete.service"
 
 
 
-const deleteUserController = async (req: Request, res: Response) => {
+export const deleteUserController = async (req: Request, res: Response): Promise<Response> => {
 
     const userId: string = req.params.id
 
@@ -12,6 +12,3 @@ const deleteUserController = async (req: Request, res: Response) => {
     return res.json(deleteUser)
 
 }
-
-
-export { deleteUserController }

--- a/src/controllers/user/retrieve.controller.ts
+++ b/src/controllers/user/retrieve.controller.ts
@@ -4,7 +4,7 @@ import { TUserResponse } from "../../interfaces/user.interfaces"
 
 
 
-const retrieveUserController = async (req: Request, res: Response) => {
+export const retrieveUserController = async (req: Request, res: Response): Promise<Response> => {
 
     const userId: string = req.params.id
 
@@ -13,6 +13,3 @@ const retrieveUserController = async (req: Request, res: Response) => {
     return res.json(user)
 
 }
-
-
-export {retrieveUserController}

--- a/src/controllers/user/update.controller.ts
+++ b/src/controllers/user/update.controller.ts
@@ -4,7 +4,7 @@ import { updateUserService } from "../../services/user/update.service"
 
 
 
-const updateUserController = async (req: Request, res: Response) => {
+export const updateUserController = async (req: Request, res: Response): Promise<Response> => {
 
     const userId: string = req.params.id
     const updatedValues: TUserUpdateRequest = req.body
@@ -14,6 +14,3 @@ const updateUserController = async (req: Request, res: Response) => {
     return res.json(updatedUser)
 
 }
-
-
-export { updateUserController }

--- a/src/middlewares/ensureDataIsValid.middleware.ts
+++ b/src/middlewares/ensureDataIsValid.middleware.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from "express"
+import { ZodTypeAny } from "zod"
+
+export const ensureDataIsValidMiddleware =
+    (schema: ZodTypeAny) =>
+        (req: Request, res: Response, next: NextFunction) => {
+            const validatedData = schema.parse(req.body)
+            req.body = validatedData
+
+            return next()
+        }
+

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -3,12 +3,14 @@ import { createUserController } from "../controllers/user/create.controller"
 import { retrieveUserController } from "../controllers/user/retrieve.controller"
 import { updateUserController } from "../controllers/user/update.controller"
 import { deleteUserController } from "../controllers/user/delete.controller"
+import { ensureDataIsValidMiddleware } from "../middlewares/ensureDataIsValid.middleware"
+import { userSchemaRequest } from "../schemas/user.schema"
 
 
 const userRoutes = Router() 
 
 
-userRoutes.post("", createUserController)
+userRoutes.post("", ensureDataIsValidMiddleware(userSchemaRequest), createUserController)
 userRoutes.get("/:id", retrieveUserController)
 userRoutes.patch("/:id", updateUserController)
 userRoutes.delete("/:id", deleteUserController)

--- a/src/schemas/ad.schema.ts
+++ b/src/schemas/ad.schema.ts
@@ -23,6 +23,7 @@ const adSchema = z.object({
   description: z.string(),
   cover_img: z.string(),
   is_active: z.boolean(),
+  user_id: z.number()
 });
 
 const adSchemaRequest = adSchema.omit({

--- a/src/schemas/user.schema.ts
+++ b/src/schemas/user.schema.ts
@@ -1,5 +1,5 @@
 import { hashSync } from "bcryptjs";
-import { z } from "zod";
+import { boolean, z } from "zod";
 
 const userSchema = z.object({
   id: z.number(),
@@ -12,6 +12,8 @@ const userSchema = z.object({
   cpf: z.string().max(11),
   phone: z.string().max(11),
   birthdate: z.string().max(8),
+  description: z.string().nullable(),
+  is_seller: z.boolean().default(false)
 });
 
 const userSchemaRequest = userSchema.omit({

--- a/src/schemas/user.schema.ts
+++ b/src/schemas/user.schema.ts
@@ -13,7 +13,7 @@ const userSchema = z.object({
   phone: z.string().max(11),
   birthdate: z.string().max(8),
   description: z.string().nullable(),
-  is_seller: z.boolean().default(false)
+  is_seller: z.boolean()
 });
 
 const userSchemaRequest = userSchema.omit({

--- a/src/services/user/create.service.ts
+++ b/src/services/user/create.service.ts
@@ -5,7 +5,7 @@ import { userSchemaResponse } from "../../schemas/user.schema"
 import { AppError } from "../../errors/errors"
 
 
-const createUserService = async (data: TUserRequest): Promise<TUserResponse> => {
+export const createUserService = async (data: TUserRequest): Promise<TUserResponse> => {
 
     const { email } = data
 
@@ -24,6 +24,3 @@ const createUserService = async (data: TUserRequest): Promise<TUserResponse> => 
 
     return userSchemaResponse.parse(user)
 }
-
-
-export { createUserService }

--- a/src/services/user/delete.service.ts
+++ b/src/services/user/delete.service.ts
@@ -4,7 +4,7 @@ import { AppError } from "../../errors/errors"
 
 
 
-const deleteUserService = async (userId: string): Promise<void> => {
+export const deleteUserService = async (userId: string): Promise<void> => {
 
     const findUser: User | null = await prisma.user.findFirst({
         where:{
@@ -24,7 +24,3 @@ const deleteUserService = async (userId: string): Promise<void> => {
     })
     
 }
-
-
-
-export { deleteUserService }

--- a/src/services/user/retrieve.service.ts
+++ b/src/services/user/retrieve.service.ts
@@ -6,7 +6,7 @@ import { AppError } from "../../errors/errors"
 
 
 
-const retrieveUserService = async (userId: string): Promise<TUserResponse> => {
+export const retrieveUserService = async (userId: string): Promise<TUserResponse> => {
 
     const user: User | null = await prisma.user.findFirst({
         where: {
@@ -21,6 +21,3 @@ const retrieveUserService = async (userId: string): Promise<TUserResponse> => {
     return userSchemaResponse.parse(user)
 
 }
-
-
-export { retrieveUserService }

--- a/src/services/user/update.service.ts
+++ b/src/services/user/update.service.ts
@@ -5,7 +5,7 @@ import { prisma } from "../../server"
 import { AppError } from "../../errors/errors"
 
 
-const updateUserService = async (data: TUserUpdateRequest, userId: string): Promise<TUserResponse> => {
+export const updateUserService = async (data: TUserUpdateRequest, userId: string): Promise<TUserResponse> => {
 
     const user: User | null = await prisma.user.findFirst({
         where: {
@@ -25,6 +25,3 @@ const updateUserService = async (data: TUserUpdateRequest, userId: string): Prom
     return userSchemaResponse.parse(userUpdated)
 
 }
-
-
-export { updateUserService }


### PR DESCRIPTION
--> Refactoring: Update on User schemas
--> Refactoring: Fix typing in User entity
--> Refactoring: Import syntax in User's controllers and services
--> Implementation: New User Migration

**Attention: After a previous update of entities [(Merge pull request #16 from g5-t14/feat/userMode)](https://github.com/g5-t14/motor-shop-api/commit/fd9895ae8330347f400f2e2cbd42debd54ebd02e), some typing will be necessary in controllers and ad services, as Prisma requires that the "user_id" field be mandatory. In this, the entries need to be typed so that the "user_id" can be optional in the entry and mandatory in the service.**