### PR TITLE
fix: now comments return username

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model Comments {
   ad_id       Int?
   user        Users?   @relation(fields: [user_id], references: [id], onDelete: Cascade)
   user_id     Int?
+  username    String   @db.VarChar(127)
 
   @@map("comments")
 }

--- a/src/controllers/comment/create.controller.ts
+++ b/src/controllers/comment/create.controller.ts
@@ -13,7 +13,7 @@ export const createCommentController = async (
   const newComment: TCommentResponse = await createCommentService(
     commentData,
     userId,
-    adId
+    adId,
   );
 
   return res.status(201).json(newComment);

--- a/src/schemas/comment.schema.ts
+++ b/src/schemas/comment.schema.ts
@@ -6,6 +6,7 @@ const commentSchema = z.object({
   ad_id: z.number(),
   description: z.string(),
   created_at: z.date(),
+  username: z.string()
 });
 
 const commentSchemaResponse = commentSchema;
@@ -15,6 +16,7 @@ const commentSchemaRequest = commentSchema.omit({
   user_id: true,
   ad_id: true,
   created_at: true,
+  username: true
 });
 
 const manyCommentSchemaResponse = z.array(commentSchema);

--- a/src/services/comment/create.service.ts
+++ b/src/services/comment/create.service.ts
@@ -5,19 +5,33 @@ import {
 } from "../../interfaces/comment.interface";
 import { prisma } from "../../server";
 import { commentSchemaResponse } from "../../schemas/comment.schema";
+import { AppError } from "../../errors/errors";
 
 export const createCommentService = async (
   data: TCommentRequest,
   userId: number,
-  adId: number
+  adId: number,
 ): Promise<TCommentResponse> => {
+  const user = await prisma.users.findUnique({
+    where:{
+      id: userId
+    }
+  })
+
+  if(user){
   const comment: Comments = await prisma.comments.create({
     data: {
       ...data,
       user_id: userId,
       ad_id: adId,
+      username: user?.name
     },
+  
   });
 
   return commentSchemaResponse.parse(comment);
+
+  }
+
+  throw new AppError("User not found!",404)
 };


### PR DESCRIPTION
## Adicionado

- Campo de 'username' no comentário

### Motivo

- Deste modo não é preciso fazer requisições extras no front para pegar o nome de cada pessoa que fez um comentário pelo id.